### PR TITLE
chore: quickstart change llama to mistral

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -58,14 +58,14 @@ For more server help, please visit:
 
 ## Getting Models
 
-`cortex run` and `cortex pull` expects a model ID, which can be a Hugging Face repo name or a cortexso model name from the [Cortex Registry](https://huggingface.co/cortexso).
+`cortex run` and `cortex pull` expects a model ID, which can be a Hugging Face repo name (ending in -GGUF) or a cortexso model name from the [Cortex Registry](https://huggingface.co/cortexso).
 
 ```bash
 # Download a model from any Hugging Face repo
 cortex pull bartowski/Hermes-2-Theta-Llama-3-70B-GGUF
 
 # Download a preconfigured model from https://huggingface.co/cortexso
-cortex pull llama3
+cortex pull mistral
 ```
 
 :::info

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,12 +23,12 @@ brew tap janhq/cortexso
 brew install cortexso
 
 # Download and run a model (compatible with your hardware):
-cortex run llama3
+cortex run mistral
 
 # Supported formats:
-cortex run llama3:gguf
-cortex run llama3:onnx
-cortex run llama3:tensorrt-llm
+cortex run mistral:gguf
+cortex run mistral:onnx
+cortex run mistral:tensorrt-llm
 ```
 
 :::info


### PR DESCRIPTION
## Describe Your Changes
Change quickstart llama3 to mistral for 5 July launch

Brew is already using `brew tap janhq/cortexso; brew install cortexso` so no change

After:
![Screenshot 2024-07-05 at 9 48 05 AM](https://github.com/janhq/cortex-web/assets/17236572/3f50d9c1-d98e-42bf-b06d-f906dbd33240)
![image](https://github.com/janhq/cortex-web/assets/17236572/cb3c176f-716a-4e6f-bbe0-45af67df1836)

Before
![Screenshot 2024-07-05 at 9 48 14 AM](https://github.com/janhq/cortex-web/assets/17236572/d6ec5bcd-ab35-4dec-adbc-5034fbbdc662)
![image](https://github.com/janhq/cortex-web/assets/17236572/71c74d4c-1256-4f3d-8a72-61d5c2c6db54)


## Fixes Issues
- Closes #79 

## Self Checklist
- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
